### PR TITLE
feat/mcp stdio time tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,31 @@ A minimal MCP (Model Context Protocol) server implemented in PHP that communicat
 
 ### Exposed Tools
 - **time.now**
-  - **Input**: `{ timeZone: string }` (required). Example: `"America/New_York"`
+  - **Input**: `{ timeZone: string }` (required). Example: "America/New_York"
   - **Output**: `{ time: string }` — ISO-8601 timestamp (`DateTimeImmutable::ATOM`).
   - **Behavior**: Validates the time zone and returns the current time for that zone; returns a structured error for invalid zones.
+
+### Usage (VS Code)
+- Install dependencies: `composer install`
+- Configure your VS Code MCP client with an `mcp.json` that points to the stdio server entrypoint. Different clients expect different top-level keys. Many VS Code clients use a top-level `servers` object; others use `mcpServers`.
+
+Example (top-level `servers`):
+```json
+{
+  "servers": {
+    "php-time": {
+      "command": "php",
+      "args": [
+        "<path_to_mmr-mcp>/bin/mcp-server.php"
+      ],
+      "env": {}
+    }
+  }
+}
+```
+
+- Adjust the path placeholder to the absolute path of `bin/mcp-server.php` on your machine.
+- Ensure no output is written to STDOUT from your tools; use STDERR for debug logs.
 
 ### More Details
 See the architecture overview for deeper context, design goals, and project layout:

--- a/bin/mcp-server.php
+++ b/bin/mcp-server.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use PhpMcp\Server\Server;
+use PhpMcp\Server\Transports\StdioServerTransport;
+
+try {
+    $server = Server::make()
+        ->withServerInfo('PHP Time Server', '0.1.0')
+        ->build();
+
+    // Discover MCP elements in src/
+    $server->discover(basePath: dirname(__DIR__), scanDirs: ['src']);
+
+    $transport = new StdioServerTransport();
+    $server->listen($transport);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "[CRITICAL] {$e->getMessage()}\n");
+    exit(1);
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "mtrichards26/mmr-mcp",
+    "description": "MCP stdio server (PHP) exposing time.now tool",
+    "type": "project",
+    "license": "MIT",
+    "require": {
+        "php-mcp/server": "^3.0"
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit --testdox"
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/TimeElements.php
+++ b/src/TimeElements.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use PhpMcp\Server\Attributes\McpTool;
+use PhpMcp\Server\Attributes\Schema;
+
+final class TimeElements
+{
+    #[McpTool(name: 'time.now', description: 'Return current time in the specified IANA time zone (ISO-8601).')]
+    public function now(
+        #[Schema(description: 'IANA time zone, e.g., America/New_York')]
+        string $timeZone
+    ): string {
+        try {
+            $dt = new \DateTimeImmutable('now', new \DateTimeZone($timeZone));
+        } catch (\Throwable $e) {
+            throw new \InvalidArgumentException("Invalid time zone: {$timeZone}");
+        }
+        return $dt->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/tests/TimeElementsTest.php
+++ b/tests/TimeElementsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\TimeElements;
+
+final class TimeElementsTest extends TestCase
+{
+    public function test_now_valid_timezone_returns_iso8601(): void
+    {
+        $tool = new TimeElements();
+        $iso = $tool->now('UTC');
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+\-]\d{2}:\d{2}|Z)$/', $iso);
+    }
+
+    public function test_now_invalid_timezone_throws(): void
+    {
+        $tool = new TimeElements();
+        $this->expectException(\InvalidArgumentException::class);
+        $tool->now('Not/AZone');
+    }
+}


### PR DESCRIPTION
- **feat: stdio MCP server with time.now tool and PHPUnit tests**
- **docs(readme): add VS Code mcp.json usage; remove invalid timeoutMs; use path placeholder**
