### PR TITLE
feat: transport switching, logging, and tool rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimal MCP (Model Context Protocol) server implemented in PHP that communicat
 - Protocol: MCP (JSON-RPC-style requests/responses)
 
 ### Exposed Tools
-- **time.now**
+- **time-now**
   - **Input**: `{ timeZone: string }` (required). Example: "America/New_York"
   - **Output**: `{ time: string }` — ISO-8601 timestamp (`DateTimeImmutable::ATOM`).
   - **Behavior**: Validates the time zone and returns the current time for that zone; returns a structured error for invalid zones.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal MCP (Model Context Protocol) server implemented in PHP that communicat
 
 ### Overview
 - Runtime: PHP 8.2+ (Composer, PSR-4 autoload)
-- Transport: stdio (stdin/stdout)
+- Transport: stdio (stdin/stdout) or Streamable HTTP
 - Protocol: MCP (JSON-RPC-style requests/responses)
 
 ### Exposed Tools
@@ -13,11 +13,40 @@ A minimal MCP (Model Context Protocol) server implemented in PHP that communicat
   - **Output**: `{ time: string }` — ISO-8601 timestamp (`DateTimeImmutable::ATOM`).
   - **Behavior**: Validates the time zone and returns the current time for that zone; returns a structured error for invalid zones.
 
+### Transport Selection
+You can switch transports without code changes using environment variables or CLI flags.
+
+- Defaults to `stdio`.
+- Env vars:
+  - `MCP_TRANSPORT`: `stdio` (default) or `http`
+  - `MCP_HTTP_HOST`: default `127.0.0.1`
+  - `MCP_HTTP_PORT`: default `8080`
+  - `MCP_HTTP_PATH`: default `/mcp`
+  - `MCP_HTTP_JSON`: `true|false` (direct JSON response on POST)
+  - `MCP_HTTP_STATELESS`: `true|false`
+- CLI flags (override env): `--transport=`, `--host=`, `--port=`, `--path=`, `--json=`, `--stateless=`
+
+Examples:
+- Stdio (default):
+  ```bash
+  php <path_to_mmr-mcp>/bin/mcp-server.php
+  ```
+- Streamable HTTP (JSON mode):
+  ```bash
+  MCP_TRANSPORT=http MCP_HTTP_HOST=127.0.0.1 MCP_HTTP_PORT=8080 MCP_HTTP_PATH=/mcp MCP_HTTP_JSON=true php <path_to_mmr-mcp>/bin/mcp-server.php
+  # or with flags (flags override env):
+  php <path_to_mmr-mcp>/bin/mcp-server.php --transport=http --host=127.0.0.1 --port=8080 --path=/mcp --json=true
+  ```
+- Streamable HTTP (SSE mode, not stateless):
+  ```bash
+  php <path_to_mmr-mcp>/bin/mcp-server.php --transport=http --json=false --stateless=false
+  ```
+
 ### Usage (VS Code)
 - Install dependencies: `composer install`
-- Configure your VS Code MCP client with an `mcp.json` that points to the stdio server entrypoint. Different clients expect different top-level keys. Many VS Code clients use a top-level `servers` object; others use `mcpServers`.
+- Configure your VS Code MCP client with an `mcp.json` that points to the server. Many VS Code clients use a top-level `servers` object.
 
-Example (top-level `servers`):
+Stdio example:
 ```json
 {
   "servers": {
@@ -32,7 +61,18 @@ Example (top-level `servers`):
 }
 ```
 
-- Adjust the path placeholder to the absolute path of `bin/mcp-server.php` on your machine.
+HTTP example (requires starting the server in HTTP mode as shown above):
+```json
+{
+  "servers": {
+    "php-time-http": {
+      "url": "http://127.0.0.1:8080/mcp"
+    }
+  }
+}
+```
+
+- Adjust placeholders and ports to match your environment.
 - Ensure no output is written to STDOUT from your tools; use STDERR for debug logs.
 
 ### More Details

--- a/bin/mcp-server.php
+++ b/bin/mcp-server.php
@@ -21,6 +21,32 @@ try {
     $config = TransportConfig::fromEnvAndArgs($_ENV + getenv(), $_SERVER['argv'] ?? []);
     $transport = TransportFactory::make($config);
 
+    // Choose output stream: avoid STDOUT in stdio mode to prevent corrupting JSON-RPC frames
+    $outputStream = ($config->transport === TransportConfig::TRANSPORT_STDIO) ? STDERR : STDOUT;
+
+    // Print effective configuration
+    fwrite($outputStream, "MCP Server configuration:\n");
+    fwrite($outputStream, sprintf("  transport: %s\n", $config->transport));
+    if ($config->transport === TransportConfig::TRANSPORT_HTTP) {
+        fwrite($outputStream, sprintf("  host: %s\n", $config->host));
+        fwrite($outputStream, sprintf("  port: %d\n", $config->port));
+        fwrite($outputStream, sprintf("  path: %s\n", $config->path));
+        fwrite($outputStream, sprintf("  json_response: %s\n", $config->enableJsonResponse ? 'true' : 'false'));
+        fwrite($outputStream, sprintf("  stateless: %s\n", $config->stateless ? 'true' : 'false'));
+        fwrite($outputStream, "\n");
+    }
+
+    // Announce when ready
+    $transport->once('ready', function () use ($outputStream, $config): void {
+        if ($config->transport === TransportConfig::TRANSPORT_HTTP) {
+            $scheme = 'http';
+            $base = sprintf('%s://%s:%d', $scheme, $config->host, $config->port);
+            fwrite($outputStream, sprintf("Server started and listening at %s%s\n", $base, $config->path));
+        } else {
+            fwrite($outputStream, "Server started and listening on stdio\n");
+        }
+    });
+
     $server->listen($transport);
 } catch (\Throwable $e) {
     fwrite(STDERR, "[CRITICAL] {$e->getMessage()}\n");

--- a/bin/mcp-server.php
+++ b/bin/mcp-server.php
@@ -8,21 +8,35 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use PhpMcp\Server\Server;
 use App\Config\TransportConfig;
 use App\Transport\TransportFactory;
+use App\Bootstrap\LoggerFactory;
+use PhpMcp\Server\Defaults\BasicContainer;
+use Psr\Log\LoggerInterface;
 
 try {
+    $logger = LoggerFactory::make('mcp');
+
+    // Provide a basic container and register the logger instance so handlers can be constructed with it
+    $container = new BasicContainer();
+    $container->set(LoggerInterface::class, $logger);
+
     $server = Server::make()
         ->withServerInfo('PHP Time Server', '0.2.0')
+        ->withLogger($logger)
+        ->withContainer($container)
         ->build();
+
+    $logger->info('Server built');
 
     // Discover MCP elements in src/
     $server->discover(basePath: dirname(__DIR__), scanDirs: ['src']);
+    $logger->info('Discovery completed', ['basePath' => dirname(__DIR__), 'scanDirs' => ['src']]);
 
     // Select transport via env/args
     $config = TransportConfig::fromEnvAndArgs($_ENV + getenv(), $_SERVER['argv'] ?? []);
     $transport = TransportFactory::make($config);
 
-    // In HTTP mode, print effective configuration and a ready message to STDOUT
     if ($config->transport === TransportConfig::TRANSPORT_HTTP) {
+        // Print effective configuration and a ready message to STDOUT
         fwrite(STDOUT, "MCP Server configuration:\n");
         fwrite(STDOUT, sprintf("  transport: %s\n", $config->transport));
         fwrite(STDOUT, sprintf("  host: %s\n", $config->host));
@@ -30,16 +44,33 @@ try {
         fwrite(STDOUT, sprintf("  path: %s\n", $config->path));
         fwrite(STDOUT, sprintf("  json_response: %s\n", $config->enableJsonResponse ? 'true' : 'false'));
         fwrite(STDOUT, sprintf("  stateless: %s\n\n", $config->stateless ? 'true' : 'false'));
+    }
 
-        $transport->once('ready', function () use ($config): void {
+    $logger->info('Transport configured', [
+        'transport' => $config->transport,
+        'host' => $config->host,
+        'port' => $config->port,
+        'path' => $config->path,
+        'json_response' => $config->enableJsonResponse,
+        'stateless' => $config->stateless,
+    ]);
+
+    $transport->once('ready', function () use ($config, $logger): void {
+        if ($config->transport === TransportConfig::TRANSPORT_HTTP) {
             $scheme = 'http';
             $base = sprintf('%s://%s:%d', $scheme, $config->host, $config->port);
             fwrite(STDOUT, sprintf("Server started and listening at %s%s\n", $base, $config->path));
-        });
-    }
+        }
+        $logger->info('Server ready');
+    });
 
+    $logger->info('Starting listener');
     $server->listen($transport);
 } catch (\Throwable $e) {
+    // Critical errors to STDERR and logger
     fwrite(STDERR, "[CRITICAL] {$e->getMessage()}\n");
+    if (isset($logger)) {
+        $logger->error('Fatal error', ['exception' => $e]);
+    }
     exit(1);
 }

--- a/bin/mcp-server.php
+++ b/bin/mcp-server.php
@@ -6,17 +6,21 @@ declare(strict_types=1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 use PhpMcp\Server\Server;
-use PhpMcp\Server\Transports\StdioServerTransport;
+use App\Config\TransportConfig;
+use App\Transport\TransportFactory;
 
 try {
     $server = Server::make()
-        ->withServerInfo('PHP Time Server', '0.1.0')
+        ->withServerInfo('PHP Time Server', '0.2.0')
         ->build();
 
     // Discover MCP elements in src/
     $server->discover(basePath: dirname(__DIR__), scanDirs: ['src']);
 
-    $transport = new StdioServerTransport();
+    // Select transport via env/args
+    $config = TransportConfig::fromEnvAndArgs($_ENV + getenv(), $_SERVER['argv'] ?? []);
+    $transport = TransportFactory::make($config);
+
     $server->listen($transport);
 } catch (\Throwable $e) {
     fwrite(STDERR, "[CRITICAL] {$e->getMessage()}\n");

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "name": "mtrichards26/mmr-mcp",
-    "description": "MCP stdio server (PHP) exposing time.now tool",
+    "description": "MCP stdio server (PHP) exposing time-now tool",
     "type": "project",
     "license": "MIT",
     "require": {
-        "php-mcp/server": "^3.0"
+        "php-mcp/server": "^3.0",
+        "monolog/monolog": "^3.6"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/docs/arch-overview.md
+++ b/docs/arch-overview.md
@@ -4,19 +4,31 @@ This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP f
 
 ## Runtime & Transport
 - **PHP**: 8.2+ (Composer, PSR-4 autoload)
-- **Transport**: stdio (long-lived process; JSON frames over stdin/stdout)
+- **Transports**:
+  - `stdio` (default): long-lived process; JSON frames over stdin/stdout
+  - `Streamable HTTP`: event-driven HTTP server with resumability/JSON-response mode
 - **Protocol**: MCP with JSON-RPC-style request/response
 
 ## Composition Root (Bootstrap)
 - Advertise server metadata and capabilities (tools)
-- Configure stdio transport
-- Register tools via a tool registry
-- Optional PSR-3 logger to stderr
-- Run main loop; exit gracefully on stdin close
+- Discover tools via attribute scanning in `src/`
+- Select transport using `App\Config\TransportConfig` and `App\Transport\TransportFactory`
+- Run main loop; exit gracefully on transport close
+
+## Transport Selection (Config)
+- `TransportConfig` parses env + CLI args:
+  - `MCP_TRANSPORT`: `stdio` (default) or `http`
+  - `MCP_HTTP_HOST` (default `127.0.0.1`)
+  - `MCP_HTTP_PORT` (default `8080`)
+  - `MCP_HTTP_PATH` (default `/mcp`)
+  - `MCP_HTTP_JSON` (`true` returns direct JSON on POST)
+  - `MCP_HTTP_STATELESS` (`false` by default)
+- CLI flags (override env): `--transport=`, `--host=`, `--port=`, `--path=`, `--json=`, `--stateless=`
+- `TransportFactory` builds either `StdioServerTransport` or `StreamableHttpServerTransport` using the parsed config
 
 ## Tool: `time.now`
 - **Purpose**: Return current time for a given IANA time zone
-- **Input schema**: `{ timeZone: string }` (required), e.g., "America/New_York"
+- **Input schema**: `{ timeZone: string }` (required), example "America/New_York"
 - **Output schema**: `{ time: string }` where `time` is ISO-8601 (`DateTimeImmutable::ATOM`)
 - **Behavior**:
   - Validate `timeZone`; on invalid value, return structured MCP error
@@ -37,31 +49,33 @@ This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP f
 - Minimal structured logging to stderr for lifecycle and errors
 
 ## Configuration
-- No external config initially
-- Optional future default timezone fallback to `UTC`
+- No external config initially for tools
+- Transport controlled via env/CLI (see above)
 
 ## Testing
 - **Unit (PHPUnit)**:
   - Valid timezone → ISO-8601 time string
   - Invalid timezone → expected MCP error type/message
-  - Use `FrozenClock`
+  - `TransportConfigTest` validates env/arg parsing & precedence
 - **Optional integration**:
-  - Spawn entrypoint subprocess
-  - Send `initialize` then `tools/call time.now`
-  - Assert response structure
+  - Spawn entrypoint subprocess for stdio
+  - For HTTP, send `initialize`/`tools/call` to the configured endpoint
 
 ## Project Layout
 ```
 /Users/mattrichards/source/mmr-mcp
 ├─ bin/
-│  └─ mcp-time                 # entrypoint (#!/usr/bin/env php)
+│  └─ mcp-server.php            # entrypoint (transport selection via env/args)
 ├─ src/
 │  ├─ Bootstrap/ServerFactory.php
+│  ├─ Config/TransportConfig.php
+│  ├─ Transport/TransportFactory.php
 │  ├─ Domain/Clock/ClockInterface.php
 │  ├─ Infrastructure/Clock/SystemClock.php
 │  └─ Tools/TimeNowTool.php
 ├─ tests/
 │  ├─ Unit/Tools/TimeNowToolTest.php
+│  ├─ TransportConfigTest.php
 │  └─ Support/FrozenClock.php
 ├─ docs/
 │  └─ arch-overview.md
@@ -70,21 +84,21 @@ This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP f
 ```
 
 ## Dependencies (to confirm during implementation)
-- PHP MCP server framework (server runtime, tool registration, stdio transport)
+- PHP MCP server framework (server runtime, tool registration, stdio & streamable HTTP transports)
 - `phpunit/phpunit` (dev)
 - Optional: `monolog/monolog`, `phpstan/phpstan`
 
 ## MCP Flow (Happy Path)
-1. Client launches server over stdio
+1. Client launches server over stdio OR connects to HTTP endpoint
 2. Client sends `initialize`; server returns metadata and tool descriptors
-3. Client calls `tools/call` for `time.now` with `{ timeZone }`
+3. Client calls `tools/call` for `time.now`
 4. Server validates, invokes tool, returns `{ time }` or structured error
-5. Server exits when stdin closes
+5. Server exits when stdin closes (stdio) or transport stops (HTTP)
 
 ## Non-Goals (Initial)
-- No persistence, networking, auth, or external config
+- No persistence, networking, auth, or external config for tools
 
 ## Extensibility
 - Register additional tools in the same composition root
 - Reuse infrastructure (logging, validation, clocks)
-- Swap transports if supported by the framework
+- Swap transports or tune HTTP options via the config without code changes

--- a/docs/arch-overview.md
+++ b/docs/arch-overview.md
@@ -1,6 +1,6 @@
 ### MCP PHP Server — Architecture Overview
 
-This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP framework with stdio transport. It exposes a single tool `time.now` that returns the current time for a requested IANA time zone. The design favors separation of concerns, testability, and protocol-compliant error handling.
+This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP framework with stdio transport. It exposes a single tool `time-now` that returns the current time for a requested IANA time zone. The design favors separation of concerns, testability, and protocol-compliant error handling.
 
 ## Runtime & Transport
 - **PHP**: 8.2+ (Composer, PSR-4 autoload)
@@ -26,7 +26,7 @@ This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP f
 - CLI flags (override env): `--transport=`, `--host=`, `--port=`, `--path=`, `--json=`, `--stateless=`
 - `TransportFactory` builds either `StdioServerTransport` or `StreamableHttpServerTransport` using the parsed config
 
-## Tool: `time.now`
+## Tool: `time-now`
 - **Purpose**: Return current time for a given IANA time zone
 - **Input schema**: `{ timeZone: string }` (required), example "America/New_York"
 - **Output schema**: `{ time: string }` where `time` is ISO-8601 (`DateTimeImmutable::ATOM`)
@@ -91,7 +91,7 @@ This outlines a simple MCP (Model Context Protocol) server in PHP using an MCP f
 ## MCP Flow (Happy Path)
 1. Client launches server over stdio OR connects to HTTP endpoint
 2. Client sends `initialize`; server returns metadata and tool descriptors
-3. Client calls `tools/call` for `time.now`
+3. Client calls `tools/call` for `time-now`
 4. Server validates, invokes tool, returns `{ time }` or structured error
 5. Server exits when stdin closes (stdio) or transport stops (HTTP)
 

--- a/src/Bootstrap/LoggerFactory.php
+++ b/src/Bootstrap/LoggerFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Bootstrap;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+final class LoggerFactory
+{
+    public static function make(string $channel = 'mcp'): LoggerInterface
+    {
+        $logger = new Logger($channel);
+
+        $logDir = __DIR__ . '/../../logs';
+
+        // File handler at INFO+; fallback silently if path cannot be opened
+        try {
+            $fileHandler = new StreamHandler($logDir . '/mcp-out.log', Level::Info);
+            $logger->pushHandler($fileHandler);
+        } catch (\Throwable) {
+            // If file cannot be opened, we still have STDERR below
+        }
+
+        // STDERR handler at ERROR+
+        $stderrHandler = new StreamHandler('php://stderr', Level::Error);
+        $logger->pushHandler($stderrHandler);
+
+        return $logger;
+    }
+}

--- a/src/Bootstrap/LoggerFactory.php
+++ b/src/Bootstrap/LoggerFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Bootstrap;
 
+use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
 use Monolog\Logger;
@@ -16,13 +17,16 @@ final class LoggerFactory
         $logger = new Logger($channel);
 
         $logDir = __DIR__ . '/../../logs';
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0775, true);
+        }
 
-        // File handler at INFO+; fallback silently if path cannot be opened
+        // Rotating file handler: daily logs, keep last 5 files
         try {
-            $fileHandler = new StreamHandler($logDir . '/mcp-out.log', Level::Info);
-            $logger->pushHandler($fileHandler);
+            $rotating = new RotatingFileHandler($logDir . '/mcp-out.log', 5, Level::Info);
+            $logger->pushHandler($rotating);
         } catch (\Throwable) {
-            // If file cannot be opened, we still have STDERR below
+            // If file cannot be opened, fallback only to STDERR
         }
 
         // STDERR handler at ERROR+

--- a/src/Config/TransportConfig.php
+++ b/src/Config/TransportConfig.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config;
+
+final class TransportConfig
+{
+    public const TRANSPORT_STDIO = 'stdio';
+    public const TRANSPORT_HTTP = 'http';
+
+    public function __construct(
+        public readonly string $transport, // 'stdio' | 'http'
+        public readonly string $host = '127.0.0.1',
+        public readonly int $port = 8080,
+        public readonly string $path = '/mcp',
+        public readonly bool $enableJsonResponse = true,
+        public readonly bool $stateless = false
+    ) {
+        if (!in_array($this->transport, [self::TRANSPORT_STDIO, self::TRANSPORT_HTTP], true)) {
+            throw new \InvalidArgumentException('Invalid transport: ' . $this->transport);
+        }
+        if ($this->transport === self::TRANSPORT_HTTP) {
+            if ($this->host === '') {
+                throw new \InvalidArgumentException('HTTP host cannot be empty');
+            }
+            if ($this->port < 1 || $this->port > 65535) {
+                throw new \InvalidArgumentException('HTTP port must be between 1 and 65535');
+            }
+            if ($this->path === '') {
+                throw new \InvalidArgumentException('HTTP path cannot be empty');
+            }
+        }
+    }
+
+    public static function fromEnvAndArgs(array $env, array $argv): self
+    {
+        // Defaults
+        $transport = self::TRANSPORT_STDIO;
+        $host = '127.0.0.1';
+        $port = 8080;
+        $path = '/mcp';
+        $enableJson = true;
+        $stateless = false;
+
+        // Env
+        $transport = self::valueOr($env['MCP_TRANSPORT'] ?? null, $transport);
+        $host = self::valueOr($env['MCP_HTTP_HOST'] ?? null, $host);
+        $port = (int) self::valueOr($env['MCP_HTTP_PORT'] ?? null, (string) $port);
+        $path = self::valueOr($env['MCP_HTTP_PATH'] ?? null, $path);
+        $enableJson = self::boolOr($env['MCP_HTTP_JSON'] ?? null, $enableJson);
+        $stateless = self::boolOr($env['MCP_HTTP_STATELESS'] ?? null, $stateless);
+
+        // Args like --key=value
+        foreach (self::parseArgs($argv) as $key => $value) {
+            switch ($key) {
+                case 'transport':
+                    $transport = $value;
+                    break;
+                case 'host':
+                    $host = $value;
+                    break;
+                case 'port':
+                    $port = (int) $value;
+                    break;
+                case 'path':
+                    $path = $value;
+                    break;
+                case 'json':
+                    $enableJson = self::boolOr($value, $enableJson);
+                    break;
+                case 'stateless':
+                    $stateless = self::boolOr($value, $stateless);
+                    break;
+            }
+        }
+
+        // Normalize path to start with '/'
+        if ($path !== '' && $path[0] !== '/') {
+            $path = '/' . $path;
+        }
+
+        return new self(
+            transport: strtolower($transport),
+            host: $host,
+            port: $port,
+            path: $path,
+            enableJsonResponse: $enableJson,
+            stateless: $stateless
+        );
+    }
+
+    private static function parseArgs(array $argv): array
+    {
+        $result = [];
+        foreach ($argv as $arg) {
+            if (!is_string($arg)) {
+                continue;
+            }
+            if (!str_starts_with($arg, '--')) {
+                continue;
+            }
+            $arg = substr($arg, 2);
+            $parts = explode('=', $arg, 2);
+            $key = $parts[0] ?? '';
+            $val = $parts[1] ?? 'true';
+            if ($key !== '') {
+                $result[$key] = $val;
+            }
+        }
+        return $result;
+    }
+
+    private static function valueOr(?string $value, string $default): string
+    {
+        return ($value === null || $value === '') ? $default : $value;
+    }
+
+    private static function boolOr(null|string $value, bool $default): bool
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        $v = strtolower((string) $value);
+        return in_array($v, ['1', 'true', 'yes', 'on'], true) ? true : (in_array($v, ['0', 'false', 'no', 'off'], true) ? false : $default);
+    }
+}

--- a/src/TimeElements.php
+++ b/src/TimeElements.php
@@ -6,19 +6,35 @@ namespace App;
 
 use PhpMcp\Server\Attributes\McpTool;
 use PhpMcp\Server\Attributes\Schema;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 
-final class TimeElements
+final class TimeElements implements LoggerAwareInterface
 {
-    #[McpTool(name: 'time.now', description: 'Return current time in the specified IANA time zone (ISO-8601).')]
+    use LoggerAwareTrait;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        if ($logger !== null) {
+            $this->setLogger($logger);
+        }
+    }
+
+    #[McpTool(name: 'time-now', description: 'Return current time in the specified IANA time zone (ISO-8601).')]
     public function now(
         #[Schema(description: 'IANA time zone, e.g., America/New_York')]
         string $timeZone
     ): string {
+        $this->logger?->info('time-now called', ['timeZone' => $timeZone]);
         try {
             $dt = new \DateTimeImmutable('now', new \DateTimeZone($timeZone));
         } catch (\Throwable $e) {
+            $this->logger?->warning('Invalid time zone', ['timeZone' => $timeZone, 'error' => $e->getMessage()]);
             throw new \InvalidArgumentException("Invalid time zone: {$timeZone}");
         }
-        return $dt->format(\DateTimeInterface::ATOM);
+        $iso = $dt->format(\DateTimeInterface::ATOM);
+        $this->logger?->debug('time-now computed time', ['time' => $iso]);
+        return $iso;
     }
 }

--- a/src/Transport/TransportFactory.php
+++ b/src/Transport/TransportFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Transport;
+
+use App\Config\TransportConfig;
+use PhpMcp\Server\Transports\StdioServerTransport;
+use PhpMcp\Server\Transports\StreamableHttpServerTransport;
+use PhpMcp\Server\Contracts\ServerTransportInterface;
+
+final class TransportFactory
+{
+    public static function make(TransportConfig $config): ServerTransportInterface
+    {
+        if ($config->transport === TransportConfig::TRANSPORT_STDIO) {
+            return new StdioServerTransport();
+        }
+
+        return new StreamableHttpServerTransport(
+            host: $config->host,
+            port: $config->port,
+            mcpPath: $config->path,
+            sslContext: null,
+            enableJsonResponse: $config->enableJsonResponse,
+            stateless: $config->stateless,
+        );
+    }
+}

--- a/tests/TransportConfigTest.php
+++ b/tests/TransportConfigTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use App\Config\TransportConfig;
+
+final class TransportConfigTest extends TestCase
+{
+    public function test_defaults_stdio(): void
+    {
+        $cfg = TransportConfig::fromEnvAndArgs([], []);
+        $this->assertSame('stdio', $cfg->transport);
+    }
+
+    public function test_env_http_overrides(): void
+    {
+        $cfg = TransportConfig::fromEnvAndArgs([
+            'MCP_TRANSPORT' => 'http',
+            'MCP_HTTP_HOST' => '127.0.0.1',
+            'MCP_HTTP_PORT' => '9090',
+            'MCP_HTTP_PATH' => '/mcp',
+            'MCP_HTTP_JSON' => 'false',
+            'MCP_HTTP_STATELESS' => 'true',
+        ], []);
+
+        $this->assertSame('http', $cfg->transport);
+        $this->assertSame('127.0.0.1', $cfg->host);
+        $this->assertSame(9090, $cfg->port);
+        $this->assertSame('/mcp', $cfg->path);
+        $this->assertFalse($cfg->enableJsonResponse);
+        $this->assertTrue($cfg->stateless);
+    }
+
+    public function test_args_override_env(): void
+    {
+        $env = [
+            'MCP_TRANSPORT' => 'stdio',
+            'MCP_HTTP_PORT' => '8080',
+        ];
+        $cfg = TransportConfig::fromEnvAndArgs($env, ['script.php', '--transport=http', '--port=6060', '--path=mcp', '--json=false']);
+        $this->assertSame('http', $cfg->transport);
+        $this->assertSame(6060, $cfg->port);
+        $this->assertSame('/mcp', $cfg->path);
+        $this->assertFalse($cfg->enableJsonResponse);
+    }
+}


### PR DESCRIPTION
This PR adds configurable transport switching (stdio/http), integrates Monolog with rotating logs (daily, keep 5, DEBUG+), suppresses stdio startup output while printing HTTP config/ready, and renames the tool to time-now. Includes docs and tests.